### PR TITLE
add support for group merging

### DIFF
--- a/main.go
+++ b/main.go
@@ -272,12 +272,13 @@ func addParentPathComments(parentDoc *ParsedDocument) error {
 		default:
 			pathComment(parentSection, parentDoc.Path)
 		case *jwcc.Array:
-			if len(parentSection.Value.(*jwcc.Array).Values) != 0 {
-				pathComment(parentSection.Value.(*jwcc.Array).Values[0], parentDoc.Path)
+			for _, val := range parentSection.Value.(*jwcc.Array).Values {
+				pathComment(val, parentDoc.Path)
 			}
 		case *jwcc.Object:
-			if len(parentSection.Value.(*jwcc.Object).Members) != 0 {
-				pathComment(parentSection.Value.(*jwcc.Object).Members[0], parentDoc.Path)
+			// Add comment to ALL members so sorting works correctly
+			for _, member := range parentSection.Value.(*jwcc.Object).Members {
+				pathComment(member, parentDoc.Path)
 			}
 		}
 	}

--- a/main.go
+++ b/main.go
@@ -175,6 +175,15 @@ func handleObject() SectionHandler {
 
 				if existingIsArr && newIsArr {
 					mergedArr := mergeArraysWithDedup(existingArr, newArr)
+
+					if existingComments := existingArr.Comments(); existingComments != nil {
+						if mergedComments := mergedArr.Comments(); mergedComments != nil {
+							mergedComments.Before = existingComments.Before
+							mergedComments.Line = existingComments.Line
+							mergedComments.End = existingComments.End
+						}
+					}
+
 					existingMember.Value = mergedArr
 
 					addMergeComment(existingMember, parentPath, childPath)

--- a/main.go
+++ b/main.go
@@ -177,7 +177,7 @@ func handleObject() SectionHandler {
 					mergedArr := mergeArraysWithDedup(existingArr, newArr)
 					existingMember.Value = mergedArr
 
-					addMergeComment(existingMember, childPath)
+					addMergeComment(existingMember, parentPath, childPath)
 					continue
 				}
 			}
@@ -218,9 +218,20 @@ func mergeArraysWithDedup(existing *jwcc.Array, new *jwcc.Array) *jwcc.Array {
 	return result
 }
 
-func addMergeComment(member *jwcc.Member, path string) {
+func addMergeComment(member *jwcc.Member, parentPath string, childPath string) {
 	existingComments := member.Comments().Before
-	newComment := fmt.Sprintf("and `%s`", path)
+
+	if len(existingComments) == 0 {
+		existingComments = []string{fmt.Sprintf("from `%s`", parentPath)}
+	}
+
+	newComment := fmt.Sprintf("and `%s`", childPath)
+	for _, c := range existingComments {
+		if c == newComment || c == fmt.Sprintf("from `%s`", childPath) {
+			return
+		}
+	}
+
 	member.Comments().Before = append(existingComments, newComment)
 }
 

--- a/main_test.go
+++ b/main_test.go
@@ -951,8 +951,14 @@ func TestHandleObjectPreservesDistinctGroups(t *testing.T) {
 }
 
 func TestMergeArraysWithDedup(t *testing.T) {
-	arr1, _ := jwcc.Parse(strings.NewReader(`["a", "b", "c"]`))
-	arr2, _ := jwcc.Parse(strings.NewReader(`["b", "c", "d"]`))
+	arr1, err := jwcc.Parse(strings.NewReader(`["a", "b", "c"]`))
+	if err != nil {
+		t.Fatalf("expected no error, got [%v]", err)
+	}
+	arr2, err := jwcc.Parse(strings.NewReader(`["b", "c", "d"]`))
+	if err != nil {
+		t.Fatalf("expected no error, got [%v]", err)
+	}
 
 	result := mergeArraysWithDedup(arr1.Value.(*jwcc.Array), arr2.Value.(*jwcc.Array))
 
@@ -974,8 +980,14 @@ func TestMergeArraysWithDedup(t *testing.T) {
 }
 
 func TestMergeArraysWithDedupEmptyArrays(t *testing.T) {
-	arr1, _ := jwcc.Parse(strings.NewReader(`[]`))
-	arr2, _ := jwcc.Parse(strings.NewReader(`["a"]`))
+	arr1, err := jwcc.Parse(strings.NewReader(`[]`))
+	if err != nil {
+		t.Fatalf("expected no error, got [%v]", err)
+	}
+	arr2, err := jwcc.Parse(strings.NewReader(`["a"]`))
+	if err != nil {
+		t.Fatalf("expected no error, got [%v]", err)
+	}
 
 	result := mergeArraysWithDedup(arr1.Value.(*jwcc.Array), arr2.Value.(*jwcc.Array))
 	if len(result.Values) != 1 {


### PR DESCRIPTION
Previously, when the same group name was defined in multiple child files, each definition was added separately, causing duplicate key errors (#34).

```bash
duplicate name "group:group-name" in object (lines X:Y and Z:Y)
```

This change:
- Merges group members when the same group name appears in multiple files
- Deduplicates members during merge
- Tracks all source files in comments (from/and format)
- Sorts object members by source so same-source items appear together
- Dedupes consecutive identical comments to reduce noise

Groups and other ACL sections handled with `handleObject()` that are defined across multiple files now combine into a single definition. Following the example from #34 :
```json
{
    "groups": {
        // from `companies/company-1/groups.hujson`
        // and `companies/company-2/groups.hujson`
        "group:group-name": [
            "member-1@company.com",
            "member-2@company.com",
            "member-3@company.com",
            "member-4@company.com",
        ]
    }
}
```

Tested this in my org and works as expected.